### PR TITLE
fix: gemini thinkingConfig type error blocking build

### DIFF
--- a/web/src/app/api/chat/gemini.ts
+++ b/web/src/app/api/chat/gemini.ts
@@ -47,11 +47,13 @@ export async function getGeminiReply(
 	const model = genAI.getGenerativeModel({
 		model: "gemini-2.5-pro",
 		systemInstruction: GEMINI_SYSTEM_INSTRUCTION,
+		// thinkingConfig is valid for gemini-2.5-pro but not yet typed in @google/generative-ai@0.24.1
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		generationConfig: {
 			responseMimeType: "application/json",
 			maxOutputTokens: 8192,
 			thinkingConfig: { thinkingBudget: -1 },
-		},
+		} as any,
 	});
 
 	const chatHistory = (history ?? []).map((h) => ({


### PR DESCRIPTION
## What changed

Cast `generationConfig` to `any` in `web/src/app/api/chat/gemini.ts` to suppress a TypeScript type error on `thinkingConfig`.

## Why

`thinkingConfig` is a valid runtime property for `gemini-2.5-pro` (controls the thinking budget for the model's reasoning pass), but it is not yet declared in `GenerationConfig` in `@google/generative-ai@0.24.1`. This caused the production build to fail:

```
Type error: Object literal may only specify known properties, and 'thinkingConfig' does not exist in type 'GenerationConfig'.
```

The `as any` cast keeps the runtime behavior intact while unblocking the build. Once the upstream package adds the type, the cast can be removed.